### PR TITLE
Fixes up some failing tests, adds travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# mdrip
+
+[![Build Status](https://travis-ci.org/monopole/mdrip.svg?branch=master)](https://travis-ci.org/monopole/mdrip)
 
 This tool makes markdown-based coding tutorials executable and
 testable.  It's a hacky, markdown-based instance of

--- a/README.md
+++ b/README.md
@@ -117,4 +117,5 @@ system - 'real' code (in some repository) and code in the discussion
 (e.g.  on a wiki page) are distinct and have to be kept in sync
 manually.
 
+
 Nobody has time for either approach, so the code rots.

--- a/runner_test.go
+++ b/runner_test.go
@@ -41,7 +41,7 @@ func TestWithBadStuff1(t *testing.T) {
 		0,
 		emptyCodeBlock,
 		nil,
-		"bash: line 1: notagoodcommand: command not found"}
+		"bash: line 1: notagoodcommand: command not found\n"}
 
 	labels := []string{"foo", "bar"}
 	blocks := []*codeBlock{&codeBlock{labels, "notagoodcommand\n"}}
@@ -56,7 +56,7 @@ func TestWithBadStuff2(t *testing.T) {
 		2,
 		emptyCodeBlock,
 		nil,
-		"bash: line 9: lochNessMonster: command not found"}
+		"bash: line 9: lochNessMonster: command not found\n"}
 
 	labels := []string{"foo", "bar"}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func checkFail(t *testing.T, got, want *ErrorBucket) {
 	if got.index != want.index {
 		t.Errorf("%s got\n\t%v\nwant\n\t%v", "script", got.index, want.index)
 	}
-	if got.message != want.message {
+	if strings.TrimSpace(got.message) != want.message {
 		t.Errorf("%s got\n\t%v\nwant\n\t%v", "message", got.message, want.message)
 	}
 }
@@ -41,7 +42,7 @@ func TestWithBadStuff1(t *testing.T) {
 		0,
 		emptyCodeBlock,
 		nil,
-		"bash: line 1: notagoodcommand: command not found\n"}
+		"bash: line 1: notagoodcommand: command not found"}
 
 	labels := []string{"foo", "bar"}
 	blocks := []*codeBlock{&codeBlock{labels, "notagoodcommand\n"}}
@@ -56,7 +57,7 @@ func TestWithBadStuff2(t *testing.T) {
 		2,
 		emptyCodeBlock,
 		nil,
-		"bash: line 9: lochNessMonster: command not found\n"}
+		"bash: line 9: lochNessMonster: command not found"}
 
 	labels := []string{"foo", "bar"}
 


### PR DESCRIPTION
I noticed some tests randomly failing due to extra trailing whitespace (newlines on OS X) this adds a trim around outputted messages in `checkFail()`.

I also added a travis config file, travis will still need to be [enabled for this repo](http://docs.travis-ci.com/user/getting-started) for it to work. You can see an [example of the build output here](https://travis-ci.org/jxson/mdrip/builds/64301331).