### PR TITLE
add language name support

### DIFF
--- a/util/lexer.go
+++ b/util/lexer.go
@@ -59,7 +59,7 @@ const (
 	labelMarker  = '@'
 	commentOpen  = "<!--"
 	commentClose = "-->"
-	codeFence    = "```\n"
+	codeFence    = "```"
 )
 
 const eof = -1
@@ -251,6 +251,11 @@ func lexBlockLabels(l *lexer) stateFn {
 func lexCommandBlock(l *lexer) stateFn {
 	l.pos += Pos(len(codeFence))
 	l.ignore()
+	// Ignore any language specifier.
+	if idx := strings.Index(l.input[l.pos:], "\n"); idx > -1 {
+		l.pos += Pos(idx) + 1
+		l.ignore()
+	}
 	for {
 		if strings.HasPrefix(l.input[l.pos:], codeFence) {
 			if l.pos > l.start {

--- a/util/lexer_test.go
+++ b/util/lexer_test.go
@@ -44,6 +44,12 @@ var lexTests = []lexTest{
 			{itemBlockLabel, "4"},
 			{itemCommandBlock, block2},
 			tEOF}},
+	{"blockWithLangName", "Hello <!-- @1 -->\n" +
+		"```java\nvoid main whatever\n```",
+		[]item{
+			{itemBlockLabel, "1"},
+			{itemCommandBlock, "void main whatever\n"},
+			tEOF}},
 }
 
 // collect gathers the emitted items into a slice.


### PR DESCRIPTION
This change allows users to specify language names at the beginning of
code blocks (e.g. ```java). The language specifier is thrown away by the
lexer.