### PR TITLE
read commands from a file

### DIFF
--- a/util/runner_test.go
+++ b/util/runner_test.go
@@ -53,7 +53,7 @@ func TestStartWithABadCommand(t *testing.T) {
 		0,
 		emptyCommandBlock,
 		nil,
-		"bash: line 1: notagoodcommand: command not found"}
+		"line 1: notagoodcommand: command not found"}
 
 	labels := []string{"foo", "bar"}
 	blocks := []*CommandBlock{
@@ -69,7 +69,7 @@ func TestBadCommandInTheMiddle(t *testing.T) {
 		2,
 		emptyCommandBlock,
 		nil,
-		"bash: line 9: lochNessMonster: command not found"}
+		"line 9: lochNessMonster: command not found"}
 
 	labels := []string{"foo", "bar"}
 


### PR DESCRIPTION
For your consideration!

This patch works around issues that occur if the script being tested reads from
standard input. All script commands are read into a file, this file is then fed
to bash. bash's stdin is redirected from /dev/null, so commands being tested
will not hang waiting for stdin.

@m3bm3b