### PR TITLE
doc: background mdrip in order to permit commands to be fed to shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ command line procedures.
 Render a markdown web app like this:
 <!-- @serveTutorial -->
 ```shell
-mdrip serve --port 8000 goTutorial.md
+mdrip serve --port 8000 goTutorial.md &
 ```
 Visit it at [localhost:8000](http://localhost:8000).
 
@@ -186,7 +186,7 @@ Fire up `tmux`, then try this `README` directly:
 
 <!-- @serveMdripReadme -->
 ```shell
-mdrip serve gh:monopole/mdrip/README.md
+mdrip serve gh:monopole/mdrip/README.md &
 ```
 
 To see what using a full tree of markdown looks like,
@@ -199,7 +199,7 @@ mdrip generatetestdata ${tmpdir}/mdTestData
 then serve it:
 <!-- @serveTestData -->
 ```shell
-mdrip serve ${tmpdir}/mdTestData
+mdrip serve ${tmpdir}/mdTestData &
 ```
 
 

--- a/internal/web/app/widget/helpbox/helpbox.html
+++ b/internal/web/app/widget/helpbox/helpbox.html
@@ -55,7 +55,7 @@
 
     <pre>
   GOBIN=$TMPDIR go install github.com/monopole/mdrip@latest
-  $TMPDIR/mdrip serve {{.AppState.DataSource}}
+  $TMPDIR/mdrip serve {{.AppState.DataSource}} &
 </pre>
 
     <p>


### PR DESCRIPTION
# Description

When running in tmux, the `mdrip serve` command remains in the foreground and doesn't actually pass commands to the shell. 

This pull request adjusts the documentation to include `&` after the command to instruct the shell to background the process after starting it. 

An alternative approach may be for the serve command to accept a --daemon flag and background itself. 

